### PR TITLE
multiqueue: fix deadlock going PAUSED with queues starvation

### DIFF
--- a/plugins/elements/gstmultiqueue.c
+++ b/plugins/elements/gstmultiqueue.c
@@ -1849,6 +1849,12 @@ single_queue_overrun_cb (GstDataQueue * dq, GstSingleQueue * sq)
             "Another queue is empty, bumping single queue %d max visible to %d",
             sq->id, sq->max_size.visible);
       }
+      if (IS_FILLED (sq, bytes, size.bytes)) {
+        sq->max_size.bytes = size.bytes + 100 * 1024;
+        GST_DEBUG_OBJECT (mq,
+            "Another queue is empty, bumping single queue %d max bytes to %d",
+            sq->id, sq->max_size.bytes);
+      }
     }
     /* check if we reached the hard time/bytes limits */
     gst_data_queue_get_level (oq->queue, &ssize);
@@ -1908,6 +1914,13 @@ single_queue_underrun_cb (GstDataQueue * dq, GstSingleQueue * sq)
         GST_DEBUG_OBJECT (mq,
             "queue %d is filled, bumping its max visible to %d", oq->id,
             oq->max_size.visible);
+        gst_data_queue_limits_changed (oq->queue);
+      }
+      if (IS_FILLED (oq, bytes, size.bytes)) {
+        oq->max_size.bytes = size.bytes + 100 * 1024;
+        GST_DEBUG_OBJECT (mq,
+            "queue %d is filled, bumping its max bytes to %d", oq->id,
+            oq->max_size.bytes);
         gst_data_queue_limits_changed (oq->queue);
       }
     }


### PR DESCRIPTION
With badly interleaved streams or when a downstream branch
buffers much more than the others, we might end up in a situation
in which a queue is full and another one empty.
Going to PAUSED state in that situation produces a deadlock
as one of the sink is waiting for a new buffer to preroll but
that buffer will never arrive because that queue is empty and
we can't read more data upstream because there is one branch with the
queue full.
This situation happens with badly interleaved streams or when
one branch buffers more than the other branch. Buffering in bad
network conditions with 4k HEVC streams triggers this issue much
likely, as there are constant changes to PAUSED and the default
of 2MB in bytes of the queue.
multiqueue has a already a mechanism to automatically increase the size
of the queue for buffers, to fix this problem we copyd this
same mechanism for the limits in bytes.