### PR TITLE
gstindex: fix UB after freeing a entry's copy

### DIFF
--- a/gst/gstindex.c
+++ b/gst/gstindex.c
@@ -539,6 +539,23 @@ gst_index_entry_copy (GstIndexEntry * entry)
   GstIndexEntry *new_entry = g_slice_new (GstIndexEntry);
 
   memcpy (new_entry, entry, sizeof (GstIndexEntry));
+
+  switch (entry->type) {
+    case GST_INDEX_ENTRY_ID:
+      if (entry->data.id.description) {
+        new_entry->data.id.description = g_strdup (entry->data.id.description);
+      }
+      break;
+    case GST_INDEX_ENTRY_ASSOCIATION:
+      if (entry->data.assoc.assocs) {
+        new_entry->data.assoc.assocs = g_memdup (entry->data.assoc.assocs,
+            sizeof (GstIndexAssociation) * entry->data.assoc.nassocs);
+      }
+      break;
+    default:
+      break;
+  }
+
   return new_entry;
 }
 

--- a/plugins/indexers/gstmemindex.c
+++ b/plugins/indexers/gstmemindex.c
@@ -407,6 +407,8 @@ gst_mem_index_get_assoc_entry (GstIndex * index, gint id,
         if (entry->id == id && (GST_INDEX_ASSOC_FLAGS (entry) & flags) == flags)
           break;
 
+        entry = NULL;
+
         if (method == GST_INDEX_LOOKUP_BEFORE)
           l_entry = g_list_next (l_entry);
         else if (method == GST_INDEX_LOOKUP_AFTER) {


### PR DESCRIPTION
When we copy the entry we have to do a deep copy,
otherwise when we free the copy, original entry's
data is also freed.