### PR TITLE
RDI-1893 Update RGBA format to BGRA in sdl2sink

### DIFF
--- a/subprojects/gst-plugins-bad/ext/sdl2/gstsdl2sink.c
+++ b/subprojects/gst-plugins-bad/ext/sdl2/gstsdl2sink.c
@@ -387,7 +387,7 @@ gst_sdl2_sink_class_init (GstSDL2SinkClass * class)
           GST_PAD_ALWAYS,
           GST_STATIC_CAPS ("video/x-raw, "
               /* TODO: support more formats through caps negotiation */
-              "format = RGBA,"
+              "format = BGRA,"
               /* ----------------------------------------------------------- */
               "framerate = (fraction) [ 0, MAX ], "
               "width = (int) [ 1, MAX ], " "height = (int) [ 1, MAX ]"));


### PR DESCRIPTION
It can be verified in gstlaunch example that videotestsrc pattern is shown with "inverted" colors. Similar thing happens on webcanvassrc.