### PR TITLE
gst.wasm: Delete sdl2 after moving to gst-plugins-web

### DIFF
--- a/gst.wasm.toml
+++ b/gst.wasm.toml
@@ -47,13 +47,6 @@ status = "pending"
 
 [[features]]
 remote = "origin"
-name = "wasm-main-sdl2"
-summary = "Add emscripten helper and sdl2sink"
-status = "pending"
-
-
-[[features]]
-remote = "origin"
 name = "wasm-main-wip"
 summary = "Commits in progress"
 status = "pending"


### PR DESCRIPTION
See https://github.com/fluendo/gst.wasm/pull/36