### PR TITLE
libav: add 'element_groups' option

### DIFF
--- a/subprojects/gst-libav/ext/libav/gstav.c
+++ b/subprojects/gst-libav/ext/libav/gstav.c
@@ -143,14 +143,30 @@ plugin_init (GstPlugin * plugin)
   /* build global ffmpeg param/property info */
   gst_ffmpeg_cfg_init ();
 
+#if BUILD_AUDENC
   gst_ffmpegaudenc_register (plugin);
+#endif
+#if BUILD_VIDENC
   gst_ffmpegvidenc_register (plugin);
+#endif
+#if BUILD_AUDDEC
   gst_ffmpegauddec_register (plugin);
+#endif
+#if BUILD_VIDDEC
   gst_ffmpegviddec_register (plugin);
+#endif
+#if BUILD_DEMUX
   gst_ffmpegdemux_register (plugin);
+#endif
+#if BUILD_MUX
   gst_ffmpegmux_register (plugin);
+#endif
+#if BUILD_DEINTERLACE
   gst_ffmpegdeinterlace_register (plugin);
+#endif
+#if BUILD_VIDCMP
   gst_ffmpegvidcmp_register (plugin);
+#endif
 
   /* Now we can return the pointer to the newly created Plugin object. */
   return TRUE;

--- a/subprojects/gst-libav/ext/libav/meson.build
+++ b/subprojects/gst-libav/ext/libav/meson.build
@@ -1,18 +1,17 @@
 libav_sources = [
     'gstav.c',
-    'gstavprotocol.c',
     'gstavcodecmap.c',
     'gstavutils.c',
-    'gstavaudenc.c',
-    'gstavvidenc.c',
-    'gstavauddec.c',
-    'gstavviddec.c',
     'gstavcfg.c',
-    'gstavdemux.c',
-    'gstavmux.c',
-    'gstavdeinterlace.c',
-    'gstavvidcmp.c',
 ]
+
+foreach group : element_groups
+  libav_sources += 'gstav@0@.c'.format(group)
+endforeach
+
+if 'mux' in element_groups or 'demux' in element_groups
+  libav_sources += 'gstavprotocol.c'
+endif
 
 libav_headers = [
   'gstavviddec.h',

--- a/subprojects/gst-libav/meson.build
+++ b/subprojects/gst-libav/meson.build
@@ -243,6 +243,12 @@ if host_machine.system() == 'windows'
 else
   pathsep = ':'
 endif
+
+element_groups = get_option('element_groups')
+foreach group : element_groups
+  cdata.set('BUILD_@0@'.format(group.to_upper()), '1')
+endforeach
+
 subdir('ext/libav')
 subdir('docs')
 subdir('tests')

--- a/subprojects/gst-libav/meson_options.txt
+++ b/subprojects/gst-libav/meson_options.txt
@@ -6,3 +6,4 @@ option('package-origin', type : 'string',
 option('doc', type : 'feature', value : 'auto', yield: true,
        description: 'Enable documentation.')
 option('tests', type : 'feature', value : 'auto', yield : true)
+option('element_groups', type : 'array', value : ['audenc', 'auddec', 'videnc', 'viddec', 'demux', 'mux', 'deinterlace', 'vidcmp' ], choices: ['audenc', 'auddec', 'videnc', 'viddec', 'demux', 'mux', 'deinterlace', 'vidcmp'], description : 'Groups of elements to compile into the plugin')


### PR DESCRIPTION
This allows to correctly build if FFMpeg have been configured with restricted amount of features, e.g. configuring as

-Dauto_features=disabled
-Dlibav=enabled
-Dlibav:element_groups='viddec,auddec'
-DFFmpeg:h264_decoder=enabled
-DFFmpeg:aac_decoder=enabled